### PR TITLE
Several Fixes

### DIFF
--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2576,6 +2576,9 @@ void PlayerbotFactory::InitArenaTeam()
         ObjectGuid capt = arenateam->GetCaptain();
         Player* botcaptain = ObjectAccessor::FindPlayer(capt);
 
+        if (sCharacterCache->GetCharacterArenaTeamIdByGuid(capt, arenateam->GetType()) != 0)
+            return;
+        
         if (botcaptain && botcaptain->GetTeamId() == bot->GetTeamId()) //need?
         {
             arenateam->AddMember(bot->GetGUID());

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2577,7 +2577,8 @@ void PlayerbotFactory::InitArenaTeam()
         Player* botcaptain = ObjectAccessor::FindPlayer(capt);
 
         if ((bot && bot->GetArenaTeamId(arenateam->GetSlot())) || sCharacterCache->GetCharacterArenaTeamIdByGuid(bot->GetGUID(), arenateam->GetSlot()) != 0)
-        
+            return;
+
         if (botcaptain && botcaptain->GetTeamId() == bot->GetTeamId()) //need?
         {
             arenateam->AddMember(bot->GetGUID());

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2021,7 +2021,7 @@ void PlayerbotFactory::InitMounts()
             fast = { 23225, 23223, 23222 };
             break;
         case RACE_TROLL:
-            slow = { 8588, 10796, 8592, 472 };
+            slow = { 10796, 472 };
             fast = { 23241, 23242, 23243 };
             break;
         case RACE_DRAENEI:
@@ -2412,14 +2412,14 @@ void PlayerbotFactory::InitInventoryEquip()
 
 void PlayerbotFactory::InitGuild()
 {
+    if (bot->GetGuildId())
+        return;
+
     bot->SaveToDB(false, false);
 
     // add guild tabard
     if (bot->GetGuildId() && !bot->HasItemCount(5976, 1))
         StoreItem(5976, 1);
-
-    if (bot->GetGuildId())
-        return;
 
     if (sPlayerbotAIConfig->randomBotGuilds.empty())
         RandomPlayerbotFactory::CreateRandomGuilds();

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2006,14 +2006,14 @@ void PlayerbotFactory::InitMounts()
             break;
         case RACE_NIGHTELF:
             slow = { 10789, 8394, 10793 };
-            fast = { 18766, 18767 };
+            fast = { 24252, 63637, 22723 };
             break;
         case RACE_UNDEAD_PLAYER:
             slow = { 17463, 17464, 17462 };
-            fast = { 17465, 23246 };
+            fast = { 17465, 23246, 66846 };
             break;
         case RACE_TAUREN:
-            slow = { 18990, 18989 };
+            slow = { 18990, 18989, 64657 };
             fast = { 23249, 23248, 23247 };
             break;
         case RACE_GNOME:
@@ -2021,7 +2021,7 @@ void PlayerbotFactory::InitMounts()
             fast = { 23225, 23223, 23222 };
             break;
         case RACE_TROLL:
-            slow = { 10796, 472 };
+            slow = { 10796, 10799, 8395, 472 };
             fast = { 23241, 23242, 23243 };
             break;
         case RACE_DRAENEI:

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2006,7 +2006,7 @@ void PlayerbotFactory::InitMounts()
             break;
         case RACE_NIGHTELF:
             slow = { 10789, 8394, 10793 };
-            fast = { 18766, 18767, 18902 };
+            fast = { 18766, 18767 };
             break;
         case RACE_UNDEAD_PLAYER:
             slow = { 17463, 17464, 17462 };

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2576,8 +2576,7 @@ void PlayerbotFactory::InitArenaTeam()
         ObjectGuid capt = arenateam->GetCaptain();
         Player* botcaptain = ObjectAccessor::FindPlayer(capt);
 
-        if (sCharacterCache->GetCharacterArenaTeamIdByGuid(capt, arenateam->GetType()) != 0 || botcaptain->GetArenaTeamId(arenateam->GetType()))
-            return;
+        if ((bot && bot->GetArenaTeamId(arenateam->GetSlot())) || sCharacterCache->GetCharacterArenaTeamIdByGuid(bot->GetGUID(), arenateam->GetSlot()) != 0)
         
         if (botcaptain && botcaptain->GetTeamId() == bot->GetTeamId()) //need?
         {

--- a/src/PlayerbotFactory.cpp
+++ b/src/PlayerbotFactory.cpp
@@ -2576,7 +2576,7 @@ void PlayerbotFactory::InitArenaTeam()
         ObjectGuid capt = arenateam->GetCaptain();
         Player* botcaptain = ObjectAccessor::FindPlayer(capt);
 
-        if (sCharacterCache->GetCharacterArenaTeamIdByGuid(capt, arenateam->GetType()) != 0)
+        if (sCharacterCache->GetCharacterArenaTeamIdByGuid(capt, arenateam->GetType()) != 0 || botcaptain->GetArenaTeamId(arenateam->GetType()))
             return;
         
         if (botcaptain && botcaptain->GetTeamId() == bot->GetTeamId()) //need?

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -521,8 +521,6 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
         Guild* guild = new Guild();
         if (!guild->Create(player, guildName))
         {
-            // it very strange, but sometimes Guild can't be created by unknown reason
-            // We already checked that player is exists and guildName are correct
             LOG_ERROR("playerbots", "Error creating guild [ {} ] with leader [ {} ]", guildName.c_str(), player->GetName().c_str());
             delete guild;
             continue;

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -498,10 +498,7 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
             continue;
 
         if (sGuildMgr->GetGuildByName(guildName))
-        {
-            LOG_WARN("playerbots", "GuildName %s is busy. Skipped...", guildName.c_str());
             continue;
-        }
 
         if (availableLeaders.empty())
         {
@@ -517,6 +514,9 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
             LOG_ERROR("playerbots", "ObjectAccessor Cannot find player to set leader for guild {} . Skipped...", guildName.c_str());
             continue;
         }
+
+        if (player->GetGuildId())
+            continue;
 
         Guild* guild = new Guild();
         if (!guild->Create(player, guildName))

--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -497,6 +497,12 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
         if (guildName.empty())
             continue;
 
+        if (sGuildMgr->GetGuildByName(guildName))
+        {
+            LOG_WARN("playerbots", "GuildName %s is busy. Skipped...", guildName.c_str());
+            continue;
+        }
+
         if (availableLeaders.empty())
         {
             LOG_ERROR("playerbots", "No leaders for random guilds available");
@@ -508,14 +514,16 @@ void RandomPlayerbotFactory::CreateRandomGuilds()
         Player* player = ObjectAccessor::FindPlayer(leader);
         if (!player)
         {
-            LOG_ERROR("playerbots", "Cannot find player for leader {}", player->GetName().c_str());
+            LOG_ERROR("playerbots", "ObjectAccessor Cannot find player to set leader for guild {} . Skipped...", guildName.c_str());
             continue;
         }
 
         Guild* guild = new Guild();
         if (!guild->Create(player, guildName))
         {
-            LOG_ERROR("playerbots", "Error creating guild {}", guildName.c_str());
+            // it very strange, but sometimes Guild can't be created by unknown reason
+            // We already checked that player is exists and guildName are correct
+            LOG_ERROR("playerbots", "Error creating guild [ {} ] with leader [ {} ]", guildName.c_str(), player->GetName().c_str());
             delete guild;
             continue;
         }

--- a/src/RandomPlayerbotMgr.cpp
+++ b/src/RandomPlayerbotMgr.cpp
@@ -918,7 +918,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* player)
         uint32 teleport = GetEventValue(bot, "teleport");
         if (!teleport)
         {
-            LOG_INFO("players", "Bot #%d <%s>: sent to grind", bot, player->GetName());
+            LOG_INFO("players", "Bot #{} <{}>: sent to grind", bot, player->GetName());
             RandomTeleportForLevel(player);
             Refresh(player);
             SetEventValue(bot, "teleport", 1, sPlayerbotAIConfig->maxRandomBotInWorldTime);


### PR DESCRIPTION
removed unexisting spells for mounting
moved condition for check Guild on top of method
check if GuildName is already taken by other guild
fixed NPE `if (!player) ...  player->GetName()`

TODO: 
Check Arena-team:
![изображение](https://user-images.githubusercontent.com/25766571/162462350-3854e2d5-56b9-4584-aa91-233627c0b4ab.png)

