### PR TITLE
Correct select randombot sql wildcard syntax error

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -249,7 +249,7 @@ void RandomPlayerbotFactory::CreateRandomBots()
         }
 
         std::vector<std::future<void>> dels;
-        QueryResult results = LoginDatabase.Query("SELECT id FROM account WHERE username LIKE ''{}'%%'", sPlayerbotAIConfig->randomBotAccountPrefix.c_str());
+        QueryResult results = LoginDatabase.Query("SELECT id FROM account WHERE username LIKE '{}%%'", sPlayerbotAIConfig->randomBotAccountPrefix.c_str());
         if (results)
         {
             do


### PR DESCRIPTION
Used to prevent
```
# Delete all random bot accounts (reset randombots)
AiPlayerbot.DeleteRandomBotAccounts = 1
```
from working.