### PR TITLE
Encourage hunter bots to use auto shot

### DIFF
--- a/src/strategy/generic/RangedCombatStrategy.cpp
+++ b/src/strategy/generic/RangedCombatStrategy.cpp
@@ -9,6 +9,5 @@ void RangedCombatStrategy::InitTriggers(std::vector<TriggerNode*> &triggers)
 {
     CombatStrategy::InitTriggers(triggers);
 
-    //triggers.push_back(new TriggerNode("enemy too close for shoot", NextAction::array(0, new NextAction("flee", ACTION_HIGH), nullptr)));
-    triggers.push_back(new TriggerNode("enemy too close for spell", NextAction::array(0, new NextAction("flee", ACTION_HIGH), nullptr)));
+    triggers.push_back(new TriggerNode("enemy out of spell", NextAction::array(0, new NextAction("reach spell", ACTION_HIGH), nullptr)));
 }

--- a/src/strategy/hunter/GenericHunterStrategy.cpp
+++ b/src/strategy/hunter/GenericHunterStrategy.cpp
@@ -69,6 +69,7 @@ void GenericHunterStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     CombatStrategy::InitTriggers(triggers);
 
+    triggers.push_back(new TriggerNode("enemy too close for auto shot", NextAction::array(0, new NextAction("switch to melee", ACTION_HIGH), nullptr)));
     triggers.push_back(new TriggerNode("enemy is close", NextAction::array(0, new NextAction("wing clip", ACTION_HIGH), nullptr)));
     triggers.push_back(new TriggerNode("medium threat", NextAction::array(0, new NextAction("feign death", 35.0f), nullptr)));
     triggers.push_back(new TriggerNode("hunters pet low health", NextAction::array(0, new NextAction("mend pet", ACTION_HIGH + 2), nullptr)));

--- a/src/strategy/hunter/HunterAiObjectContext.cpp
+++ b/src/strategy/hunter/HunterAiObjectContext.cpp
@@ -83,6 +83,7 @@ class HunterTriggerFactoryInternal : public NamedObjectContext<Trigger>
         }
 
     private:
+        static Trigger* auto_shot(PlayerbotAI* botAI) { return new AutoShotTrigger(botAI); }
         static Trigger* scare_beast(PlayerbotAI* botAI) { return new ScareBeastTrigger(botAI); }
         static Trigger* concussive_shot_on_snare_target(PlayerbotAI* botAI) { return new ConsussiveShotSnareTrigger(botAI); }
         static Trigger* pet_not_happy(PlayerbotAI* botAI) { return new HunterPetNotHappy(botAI); }

--- a/src/strategy/hunter/HunterTriggers.h
+++ b/src/strategy/hunter/HunterTriggers.h
@@ -12,6 +12,14 @@ class PlayerbotAI;
 BEGIN_TRIGGER(HunterNoStingsActiveTrigger, Trigger)
 END_TRIGGER()
 
+class AutoShotTrigger : public Trigger
+{
+    public:
+        AutoShotTrigger(PlayerbotAI* botAI) : Trigger(botAI, "auto shot") { }
+
+        bool IsActive() override;
+};
+
 class HunterAspectOfTheHawkTrigger : public BuffTrigger
 {
     public:

--- a/src/strategy/triggers/RangeTriggers.cpp
+++ b/src/strategy/triggers/RangeTriggers.cpp
@@ -44,6 +44,34 @@ bool EnemyTooCloseForSpellTrigger::IsActive()
     return false;
 }
 
+bool EnemyTooCloseForAutoShotTrigger::IsActive()
+{
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (!target)
+        return false;
+
+    if (target->GetTarget() == bot->GetGUID() && !bot->GetGroup() && !target->HasUnitState(UNIT_STATE_ROOT) && GetSpeedInMotion(target) > GetSpeedInMotion(bot) * 0.65f)
+        return false;
+
+    bool isBoss = false;
+    bool isRaid = false;
+    float combatReach = bot->GetCombatReach() + target->GetCombatReach();
+    float targetDistance = sServerFacade->GetDistance2d(bot, target) + combatReach;
+    if (target->GetTypeId() == TYPEID_UNIT)
+    {
+        Creature* creature = botAI->GetCreature(target->GetGUID());
+        if (creature)
+        {
+            isBoss = creature->isWorldBoss();
+        }
+    }
+
+    if (bot->GetMap() && bot->GetMap()->IsRaid())
+        isRaid = true;
+
+    return sServerFacade->IsDistanceLessOrEqualThan(targetDistance, 5.0f);
+}
+
 bool EnemyTooCloseForShootTrigger::IsActive()
 {
     Unit* target = AI_VALUE(Unit*, "current target");

--- a/src/strategy/triggers/RangeTriggers.h
+++ b/src/strategy/triggers/RangeTriggers.h
@@ -26,6 +26,14 @@ class EnemyTooCloseForShootTrigger : public Trigger
         bool IsActive() override;
 };
 
+class EnemyTooCloseForAutoShotTrigger : public Trigger
+{
+    public:
+        EnemyTooCloseForAutoShotTrigger(PlayerbotAI* botAI) : Trigger(botAI, "enemy too close for auto shot") { }
+
+        bool IsActive() override;
+};
+
 class EnemyTooCloseForMeleeTrigger : public Trigger
 {
     public:

--- a/src/strategy/triggers/TriggerContext.h
+++ b/src/strategy/triggers/TriggerContext.h
@@ -81,6 +81,7 @@ class TriggerContext : public NamedObjectContext<Trigger>
             creators["enemy out of spell"] = &TriggerContext::EnemyOutOfSpell;
             creators["enemy too close for spell"] = &TriggerContext::enemy_too_close_for_spell;
             creators["enemy too close for shoot"] = &TriggerContext::enemy_too_close_for_shoot;
+            creators["enemy too close for auto shot"] = &TriggerContext::enemy_too_close_for_auto_shot;
             creators["enemy too close for melee"] = &TriggerContext::enemy_too_close_for_melee;
             creators["enemy is close"] = &TriggerContext::enemy_is_close;
             creators["party member to heal out of spell range"] = &TriggerContext::party_member_to_heal_out_of_spell_range;
@@ -256,6 +257,7 @@ class TriggerContext : public NamedObjectContext<Trigger>
         static Trigger* EnemyOutOfMelee(PlayerbotAI* botAI) { return new EnemyOutOfMeleeTrigger(botAI); }
         static Trigger* EnemyOutOfSpell(PlayerbotAI* botAI) { return new EnemyOutOfSpellRangeTrigger(botAI); }
         static Trigger* enemy_too_close_for_spell(PlayerbotAI* botAI) { return new EnemyTooCloseForSpellTrigger(botAI); }
+        static Trigger* enemy_too_close_for_auto_shot(PlayerbotAI* botAI) { return new EnemyTooCloseForAutoShotTrigger(botAI); }
         static Trigger* enemy_too_close_for_shoot(PlayerbotAI* botAI) { return new EnemyTooCloseForShootTrigger(botAI); }
         static Trigger* enemy_too_close_for_melee(PlayerbotAI* botAI) { return new EnemyTooCloseForMeleeTrigger(botAI); }
         static Trigger* enemy_is_close(PlayerbotAI* botAI) { return new EnemyIsCloseTrigger(botAI); }


### PR DESCRIPTION
Hunter bots should now use auto shot when engaging targets in combat. If they are out of range they should move towards the target until they are within reach of the auto shot spell. When targets get too close the bot should switch to melee.