### PR TITLE
Remove targetPosRecalcDistance from distance calculations

### DIFF
--- a/src/ServerFacade.cpp
+++ b/src/ServerFacade.cpp
@@ -23,12 +23,14 @@ float ServerFacade::GetDistance2d(Unit *unit, float x, float y)
 
 bool ServerFacade::IsDistanceLessThan(float dist1, float dist2)
 {
-    return dist1 - dist2 < sPlayerbotAIConfig->targetPosRecalcDistance;
+    //return dist1 - dist2 < sPlayerbotAIConfig->targetPosRecalcDistance;
+    return dist1 < dist2;
 }
 
 bool ServerFacade::IsDistanceGreaterThan(float dist1, float dist2)
 {
-    return dist1 - dist2 > sPlayerbotAIConfig->targetPosRecalcDistance;
+    //return dist1 - dist2 > sPlayerbotAIConfig->targetPosRecalcDistance;
+    return dist1 > dist2;
 }
 
 bool ServerFacade::IsDistanceGreaterOrEqualThan(float dist1, float dist2)


### PR DESCRIPTION
This seemed to prevent spell casters and hunters using auto shot (a spell) from calculating distance correctly, causing hunters to switch to melee from 30 yards away and always running to their target to engage in combat.