### PR TITLE
Restrict random bot races by expansion

### DIFF
--- a/src/RandomPlayerbotFactory.cpp
+++ b/src/RandomPlayerbotFactory.cpp
@@ -22,12 +22,18 @@ RandomPlayerbotFactory::RandomPlayerbotFactory(uint32 accountId) : accountId(acc
     availableRaces[CLASS_WARRIOR].push_back(RACE_UNDEAD_PLAYER);
     availableRaces[CLASS_WARRIOR].push_back(RACE_TAUREN);
     availableRaces[CLASS_WARRIOR].push_back(RACE_TROLL);
-    availableRaces[CLASS_WARRIOR].push_back(RACE_DRAENEI);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_WARRIOR].push_back(RACE_DRAENEI);
+    }
 
     availableRaces[CLASS_PALADIN].push_back(RACE_HUMAN);
     availableRaces[CLASS_PALADIN].push_back(RACE_DWARF);
-    availableRaces[CLASS_PALADIN].push_back(RACE_DRAENEI);
-    availableRaces[CLASS_PALADIN].push_back(RACE_BLOODELF);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_PALADIN].push_back(RACE_DRAENEI);
+        availableRaces[CLASS_PALADIN].push_back(RACE_BLOODELF);
+    }
 
     availableRaces[CLASS_ROGUE].push_back(RACE_HUMAN);
     availableRaces[CLASS_ROGUE].push_back(RACE_DWARF);
@@ -35,7 +41,10 @@ RandomPlayerbotFactory::RandomPlayerbotFactory(uint32 accountId) : accountId(acc
     availableRaces[CLASS_ROGUE].push_back(RACE_GNOME);
     availableRaces[CLASS_ROGUE].push_back(RACE_ORC);
     availableRaces[CLASS_ROGUE].push_back(RACE_TROLL);
-    availableRaces[CLASS_ROGUE].push_back(RACE_BLOODELF);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_ROGUE].push_back(RACE_BLOODELF);
+    }
 
     availableRaces[CLASS_PRIEST].push_back(RACE_HUMAN);
     availableRaces[CLASS_PRIEST].push_back(RACE_DWARF);
@@ -43,47 +52,65 @@ RandomPlayerbotFactory::RandomPlayerbotFactory(uint32 accountId) : accountId(acc
     availableRaces[CLASS_PRIEST].push_back(RACE_TROLL);
     availableRaces[CLASS_PRIEST].push_back(RACE_UNDEAD_PLAYER);
     availableRaces[CLASS_PRIEST].push_back(RACE_DRAENEI);
-    availableRaces[CLASS_PRIEST].push_back(RACE_BLOODELF);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_PRIEST].push_back(RACE_BLOODELF);
+    }
 
     availableRaces[CLASS_MAGE].push_back(RACE_HUMAN);
     availableRaces[CLASS_MAGE].push_back(RACE_GNOME);
     availableRaces[CLASS_MAGE].push_back(RACE_UNDEAD_PLAYER);
     availableRaces[CLASS_MAGE].push_back(RACE_TROLL);
-    availableRaces[CLASS_MAGE].push_back(RACE_DRAENEI);
-    availableRaces[CLASS_MAGE].push_back(RACE_BLOODELF);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_MAGE].push_back(RACE_DRAENEI);
+        availableRaces[CLASS_MAGE].push_back(RACE_BLOODELF);
+    }
 
     availableRaces[CLASS_WARLOCK].push_back(RACE_HUMAN);
     availableRaces[CLASS_WARLOCK].push_back(RACE_GNOME);
     availableRaces[CLASS_WARLOCK].push_back(RACE_UNDEAD_PLAYER);
     availableRaces[CLASS_WARLOCK].push_back(RACE_ORC);
-    availableRaces[CLASS_WARLOCK].push_back(RACE_BLOODELF);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_WARLOCK].push_back(RACE_BLOODELF);
+    }
 
     availableRaces[CLASS_SHAMAN].push_back(RACE_ORC);
     availableRaces[CLASS_SHAMAN].push_back(RACE_TAUREN);
     availableRaces[CLASS_SHAMAN].push_back(RACE_TROLL);
-    availableRaces[CLASS_SHAMAN].push_back(RACE_DRAENEI);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_SHAMAN].push_back(RACE_DRAENEI);
+    }
 
     availableRaces[CLASS_HUNTER].push_back(RACE_DWARF);
     availableRaces[CLASS_HUNTER].push_back(RACE_NIGHTELF);
     availableRaces[CLASS_HUNTER].push_back(RACE_ORC);
     availableRaces[CLASS_HUNTER].push_back(RACE_TAUREN);
     availableRaces[CLASS_HUNTER].push_back(RACE_TROLL);
-    availableRaces[CLASS_HUNTER].push_back(RACE_DRAENEI);
-    availableRaces[CLASS_HUNTER].push_back(RACE_BLOODELF);
+    if(expansion >= EXPANSION_THE_BURNING_CRUSADE)
+    {
+        availableRaces[CLASS_HUNTER].push_back(RACE_DRAENEI);
+        availableRaces[CLASS_HUNTER].push_back(RACE_BLOODELF);
+    }
 
     availableRaces[CLASS_DRUID].push_back(RACE_NIGHTELF);
     availableRaces[CLASS_DRUID].push_back(RACE_TAUREN);
 
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_NIGHTELF);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_TAUREN);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_HUMAN);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_ORC);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_UNDEAD_PLAYER);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_TROLL);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_BLOODELF);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_DRAENEI);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_GNOME);
-    availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_DWARF);
+    if (expansion == EXPANSION_WRATH_OF_THE_LICH_KING)
+    {
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_NIGHTELF);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_TAUREN);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_HUMAN);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_ORC);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_UNDEAD_PLAYER);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_TROLL);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_BLOODELF);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_DRAENEI);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_GNOME);
+        availableRaces[CLASS_DEATH_KNIGHT].push_back(RACE_DWARF);
+    }
 }
 
 Player* RandomPlayerbotFactory::CreateRandomBot(WorldSession* session, uint8 cls, std::unordered_map<uint8, std::vector<std::string>> names)


### PR DESCRIPTION
Random bots should not be created for races that are not supported by the current expansion.