### PR TITLE
Fix SQL syntax in PlayerbotMgr.cpp

### DIFF
--- a/src/PlayerbotMgr.cpp
+++ b/src/PlayerbotMgr.cpp
@@ -958,7 +958,7 @@ void PlayerbotMgr::OnPlayerLogin(Player* player)
         return;
 
     uint32 accountId = player->GetSession()->GetAccountId();
-    QueryResult results = CharacterDatabase.Query("SELECT name FROM characters WHERE account = {}'", accountId);
+    QueryResult results = CharacterDatabase.Query("SELECT name FROM characters WHERE account = {}", accountId);
     if (results)
     {
         std::ostringstream out;


### PR DESCRIPTION
When any player logs in with `AiPlayerbot.BotAutologin = 1`, worldserver crashes with the error:

```
AC> [1064] You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ''' at line 1
Error while parsing SQL. Core fix required.
```

Just a simple sql fix.
