### PR TITLE
Fix the sitting state and solve the problem that the bot will stuck after eating or drinking

### DIFF
--- a/src/strategy/actions/NonCombatActions.cpp
+++ b/src/strategy/actions/NonCombatActions.cpp
@@ -30,7 +30,7 @@ bool DrinkAction::Execute(Event event)
             return false;
         }
 
-        bot->AddUnitState(UNIT_STAND_STATE_SIT);
+        bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
         //float hp = bot->GetHealthPercent();
@@ -82,7 +82,7 @@ bool EatAction::Execute(Event event)
             return false;
         }
 
-        bot->AddUnitState(UNIT_STAND_STATE_SIT);
+        bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
         float hp = bot->GetHealthPct();

--- a/src/strategy/actions/UseItemAction.cpp
+++ b/src/strategy/actions/UseItemAction.cpp
@@ -266,7 +266,7 @@ bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget, Uni
         if (bot->IsInCombat())
             return false;
 
-        bot->AddUnitState(UNIT_STAND_STATE_SIT);
+        bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
         float hp = bot->GetHealthPct();


### PR DESCRIPTION
https://github.com/ZhengPeiRu21/mod-playerbots/commit/9871cd34c46c661327ae333e5bce0fb67135789d

The bot gets stuck after eating or drinking. Problems are mentioned in these issues:
- https://github.com/ZhengPeiRu21/mod-playerbots/issues/37
- https://github.com/ZhengPeiRu21/mod-playerbots/issues/123
- https://github.com/ZhengPeiRu21/mod-playerbots/issues/164
- https://github.com/ZhengPeiRu21/mod-playerbots/issues/188

That is caused by the misusing of StandState related method. Replace `bot->AddUnitState(UNIT_STAND_STATE_SIT)` with `bot->SetStandState(UNIT_STAND_STATE_SIT)` and it should work. 

Actually `bot->AddUnitState(UNIT_STAND_STATE_SIT)` is equal to `bot->AddUnitState(UNIT_STATE_DIED)` because `UNIT_STATE_DIED`=`UNIT_STAND_STATE_SIT`=1, which may cause the bot to be considered dead and prevent it from moving. (not sure)